### PR TITLE
Ensure env vars present & tidy files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+venv/
 .venv/
 .env
+__pycache__/

--- a/listener.py
+++ b/listener.py
@@ -9,7 +9,30 @@ Environment variables required (Render → Environment):
   FROM_EMAIL, TO_EMAIL
 """
 
-import os, json, time, requests, psycopg
+import os
+import json
+import time
+import requests
+import psycopg
+
+# Verify that all required environment variables are present
+REQUIRED_ENV_VARS = [
+    "PGHOST",
+    "PGDATABASE",
+    "PGUSER",
+    "PGPASSWORD",
+    "TENANT_ID",
+    "CLIENT_ID",
+    "CLIENT_SECRET",
+    "FROM_EMAIL",
+    "TO_EMAIL",
+]
+
+missing_vars = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+if missing_vars:
+    raise RuntimeError(
+        "Missing required environment variables: " + ", ".join(missing_vars)
+    )
 
 # ── Microsoft Graph helpers ──────────────────────────────────────────────
 TENANT_ID     = os.getenv("TENANT_ID")


### PR DESCRIPTION
## Summary
- check for required env vars in `listener.py`
- add newline to end of script
- ignore virtual environment and caches

## Testing
- `python3 -m py_compile listener.py`
- `./venv/bin/pip install -r requirements.txt` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683ee9d06fa48330bfd767e2b59e0d49