### PR TITLE
Support second database and email channel

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -4,9 +4,11 @@ Background worker:
   • When a NOTIFY arrives, send a readable e-mail via Microsoft Graph
 
 Environment variables required (Render → Environment):
-  PGHOST, PGDATABASE, PGUSER, PGPASSWORD
+  PGHOST,  PGDATABASE,  PGUSER,  PGPASSWORD
+  PGHOST2, PGDATABASE2, PGUSER2, PGPASSWORD2  # database/user #2
   TENANT_ID, CLIENT_ID, CLIENT_SECRET
-  FROM_EMAIL, TO_EMAIL
+  FROM_EMAIL,  TO_EMAIL
+  FROM_EMAIL2, TO_EMAIL2  # e-mail account #2
 """
 
 import os
@@ -14,18 +16,15 @@ import json
 import time
 import requests
 import psycopg
+from threading import Thread
 
 # Verify that all required environment variables are present
 REQUIRED_ENV_VARS = [
-    "PGHOST",
-    "PGDATABASE",
-    "PGUSER",
-    "PGPASSWORD",
-    "TENANT_ID",
-    "CLIENT_ID",
-    "CLIENT_SECRET",
-    "FROM_EMAIL",
-    "TO_EMAIL",
+    "PGHOST", "PGDATABASE", "PGUSER", "PGPASSWORD",  # database/user #1
+    "PGHOST2", "PGDATABASE2", "PGUSER2", "PGPASSWORD2",  # database/user #2
+    "TENANT_ID", "CLIENT_ID", "CLIENT_SECRET",
+    "FROM_EMAIL", "TO_EMAIL",         # email account #1
+    "FROM_EMAIL2", "TO_EMAIL2",       # email account #2
 ]
 
 missing_vars = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
@@ -38,11 +37,18 @@ if missing_vars:
 TENANT_ID     = os.getenv("TENANT_ID")
 CLIENT_ID     = os.getenv("CLIENT_ID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
-FROM_EMAIL    = os.getenv("FROM_EMAIL")     # fateh@rpmautosales.ca
-TO_EMAIL      = os.getenv("TO_EMAIL")       # info@rpmautosales.ca
+FROM_EMAIL    = os.getenv("FROM_EMAIL")      # fateh@rpmautosales.ca
+TO_EMAIL      = os.getenv("TO_EMAIL")        # info@rpmautosales.ca
+
+# second e-mail account / database
+FROM_EMAIL2   = os.getenv("FROM_EMAIL2")
+TO_EMAIL2     = os.getenv("TO_EMAIL2")
+PGHOST2       = os.getenv("PGHOST2")
+PGDATABASE2   = os.getenv("PGDATABASE2")
+PGUSER2       = os.getenv("PGUSER2")
+PGPASSWORD2   = os.getenv("PGPASSWORD2")
 
 TOKEN_URL    = f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token"
-SENDMAIL_URL = f"https://graph.microsoft.com/v1.0/users/{FROM_EMAIL}/sendMail"
 
 _token = {"val": None, "exp": 0}
 
@@ -67,7 +73,7 @@ def graph_token() -> str:
     _token["exp"] = time.time() + int(body.get("expires_in", 3600))
     return _token["val"]
 
-def send_email(record: dict):
+def send_email(record: dict, from_email: str, to_email: str) -> None:
     """Build a clean, plain-text e-mail from an inquiry row and send it."""
     subject = "🆕 New Inquiry Received"
 
@@ -92,22 +98,23 @@ def send_email(record: dict):
         "message": {
             "subject": subject,
             "body": {"contentType": "Text", "content": body_text},
-            "toRecipients": [{"emailAddress": {"address": TO_EMAIL}}],
+            "toRecipients": [{"emailAddress": {"address": to_email}}],
         },
         "saveToSentItems": "false",
     }
-    requests.post(SENDMAIL_URL, headers=headers, json=payload, timeout=15).raise_for_status()
+    sendmail_url = f"https://graph.microsoft.com/v1.0/users/{from_email}/sendMail"
+    requests.post(sendmail_url, headers=headers, json=payload, timeout=15).raise_for_status()
 
 # ── PostgreSQL LISTEN / NOTIFY setup ─────────────────────────────────────
 
-def main() -> None:
-    """Listen for new records and send notification e-mails."""
+def listen_for_db(config: dict, from_email: str, to_email: str) -> None:
+    """Connect to the DB and process notifications."""
     conn = psycopg.connect(
-        host=os.getenv("PGHOST"),
-        dbname=os.getenv("PGDATABASE"),
-        user=os.getenv("PGUSER"),
-        password=os.getenv("PGPASSWORD"),
-        autocommit=True,  # LISTEN works best with autocommit
+        host=config["host"],
+        dbname=config["dbname"],
+        user=config["user"],
+        password=config["password"],
+        autocommit=True,
     )
 
     with conn.cursor() as cur:
@@ -115,13 +122,36 @@ def main() -> None:
 
     print("🔔  Listening on channel new_record_channel …")
 
-    for notify in conn.notifies():  # blocks until a NOTIFY is received
+    for notify in conn.notifies():
         try:
             record = json.loads(notify.payload)
-            send_email(record)
+            send_email(record, from_email, to_email)
             print("📨  Email sent for inquiry id:", record.get("id"))
         except Exception as exc:
             print("⚠️  Failed to handle notification:", exc)
+
+
+def main() -> None:
+    """Start listeners for both databases."""
+    config1 = {
+        "host": os.getenv("PGHOST"),
+        "dbname": os.getenv("PGDATABASE"),
+        "user": os.getenv("PGUSER"),
+        "password": os.getenv("PGPASSWORD"),
+    }
+    config2 = {
+        "host": PGHOST2,
+        "dbname": PGDATABASE2,
+        "user": PGUSER2,
+        "password": PGPASSWORD2,
+    }
+
+    t1 = Thread(target=listen_for_db, args=(config1, FROM_EMAIL, TO_EMAIL))
+    t2 = Thread(target=listen_for_db, args=(config2, FROM_EMAIL2, TO_EMAIL2))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add environment variables for a secondary database/email
- refactor `send_email` to accept sender/recipient
- listen for notifications from two databases concurrently
- update tests for new listener API

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68438fde312c8330b34a975f1edb17f8