### PR TITLE
Update README for dual listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+## Environment
+Set the following environment variables before running the listener:
+
+- `PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`
+- `TENANT_ID`, `CLIENT_ID`, `CLIENT_SECRET`
+- `FROM_EMAIL`, `TO_EMAIL`
+- `PGHOST_2`, `PGDATABASE_2`, `PGUSER_2`, `PGPASSWORD_2`
+- `FROM_EMAIL_2`, `TO_EMAIL_2`
+
+The variables ending with `_2` configure the second database connection
+and mail sender.
+
 ## Usage
 Set the required environment variables and start the listener:
 
@@ -23,7 +35,10 @@ python listener.py
 ```
 
 The script waits for notifications on the `new_record_channel` channel and
-emails the inquiry details when a notification is received.
+emails the inquiry details when a notification is received. It now runs two
+threads, each connected to its own database and sending mail from its
+corresponding user. The expected channel name, `new_record_channel`, remains
+the same for both databases.
 
 ## License
 This project is licensed under the terms of the [MIT](LICENSE) license.


### PR DESCRIPTION
## Summary
- document new environment variables used for the second listener
- explain that the listener now runs two threads and still expects `new_record_channel`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68438fe5cb6483308e51ab06df8a32b3